### PR TITLE
MODLD-180: Add functions for creating and destroying staging tables for merge

### DIFF
--- a/src/main/resources/changelog/scripts/v-1.0.0/metadata/changelog.xml
+++ b/src/main/resources/changelog/scripts/v-1.0.0/metadata/changelog.xml
@@ -26,5 +26,7 @@
   <include file="data/profiles.xml" relativeToChangelogFile="true"/>
   <include file="data/events.xml" relativeToChangelogFile="true"/>
   <include file="data/settings.xml" relativeToChangelogFile="true"/>
+  <include file="functions/start_event_v2.sql" relativeToChangelogFile="true"/>
+  <include file="data/scaling_exponent.sql" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/changelog/scripts/v-1.0.0/metadata/data/scaling_exponent.sql
+++ b/src/main/resources/changelog/scripts/v-1.0.0/metadata/data/scaling_exponent.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset dfeeney@ebsco.com:2.24_set_default_scaling_exponent dbms:postgresql splitStatements:false
+
+select set_configuration_setting('graph', 'scaling_exponent', 2::text);

--- a/src/main/resources/changelog/scripts/v-1.0.0/metadata/functions/start_event_v2.sql
+++ b/src/main/resources/changelog/scripts/v-1.0.0/metadata/functions/start_event_v2.sql
@@ -1,0 +1,37 @@
+--liquibase formatted sql
+
+--changeset dfeeney@ebsco.com:2.23_fix_start_event_function dbms:postgresql splitStatements:false
+
+do $do$
+  BEGIN
+
+    execute format($format$
+
+    create or replace function %1$I.start_event(in_event_uri text) returns bigint as
+    $create_event$
+    DECLARE
+      generated_id bigint;
+      event_hash bigint;
+    BEGIN
+      select event_uri_hash into event_hash from %1$I.event_lookup  where event_uri=in_event_uri;
+      if event_hash is null then
+        raise exception 'Nonexistent event --> %%', in_event_uri;
+      end if;
+
+      insert into %1$I.events(event_uri_hash, created)
+      values (event_hash, transaction_timestamp())
+      returning id into generated_id;
+
+      return generated_id;
+    END
+    $create_event$
+    language plpgsql;
+
+    comment on function %1$I.start_event(text) is 'Start a new event on the graph';
+
+  $format$, CURRENT_SCHEMA);
+  END;
+$do$;
+
+
+--rollback drop function if exists  start_event(text);

--- a/src/main/resources/changelog/scripts/v-1.0.0/resource_graph/changelog.xml
+++ b/src/main/resources/changelog/scripts/v-1.0.0/resource_graph/changelog.xml
@@ -16,4 +16,7 @@
 
   <include file="data/insert-mod-linked-data-monograph-predicates.xml" relativeToChangelogFile="true"/>
   <include file="data/insert-mod-linked-data-monograph-types.xml" relativeToChangelogFile="true"/>
+
+  <include file="functions/drop_staging_tables.sql" relativeToChangelogFile="true"/>
+  <include file="functions/create_staging_tables.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/scripts/v-1.0.0/resource_graph/functions/create_staging_tables.sql
+++ b/src/main/resources/changelog/scripts/v-1.0.0/resource_graph/functions/create_staging_tables.sql
@@ -1,0 +1,103 @@
+--liquibase formatted sql
+
+--changeset dfeeney@ebsco.com:3.12_create_staging_tables_function dbms:postgresql splitStatements:false
+do $do$
+  BEGIN
+
+    execute format($format$
+      create or replace function %1$I.create_staging_tables() returns boolean as
+      $create_staging_tables$
+      DECLARE
+        partitioned_list text[] := array[
+          'resources_staging',
+          'resource_edges_staging',
+          'resource_generator_map_staging',
+          'generator_manifest_staging',
+          'resource_context_map_staging',
+          'resource_type_map_staging'
+        ];
+        scaling_exponent integer;
+        partition_count integer;
+        staging_table text;
+      BEGIN
+        scaling_exponent := %1$I.get_configuration_setting('graph', 'scaling_exponent')::int;
+        if scaling_exponent < 0 then
+            scaling_exponent := 2;
+        end if;
+
+        partition_count := power(2, scaling_exponent);
+
+        perform %1$I.drop_staging_tables();
+
+        create unlogged table %1$I.resources_staging(
+          resource_hash bigint,
+          label text,
+          doc jsonb
+        ) partition by hash(resource_hash);
+
+        create unlogged table %1$I.resource_edges_staging(
+          source_hash bigint,
+          target_hash bigint,
+          predicate_hash bigint
+        ) partition by hash(source_hash);
+
+        create unlogged table %1$I.resource_generator_map_staging(
+          generator_hash bigint,
+          resource_hash bigint
+        ) partition by hash(generator_hash);
+
+        create unlogged table %1$I.generator_manifest_staging(
+          input_hash bigint,
+          concrete_hash bigint,
+          generator_hash bigint,
+          conceptual_hash bigint
+        ) partition by hash(generator_hash);
+
+        create unlogged table %1$I.resource_context_map_staging(
+          resource_hash bigint,
+          context_hash bigint
+        ) partition by hash(resource_hash);
+
+        create unlogged table %1$I.resource_type_map_staging(
+          resource_hash bigint,
+          type_hash bigint
+        ) partition by hash(resource_hash);
+
+        foreach staging_table in array partitioned_list loop
+          for loop_count in 0..(partition_count - 1) loop
+              execute format($partition_create$
+                  create unlogged table if not exists %1$I.%%1$s_%%2$s_%%3$s partition of %1$I.%%1$I for values with (modulus %%2$s, remainder %%3$s);
+              $partition_create$, staging_table, partition_count, loop_count);
+          end loop;
+        end loop;
+
+        create unlogged table %1$I.context_lookup_staging (
+          context_hash bigint,
+          context_uri text
+        );
+
+
+        create unlogged table %1$I.predicate_lookup_staging (
+          predicate_hash bigint,
+          predicate text
+        );
+
+        create unlogged table %1$I.type_lookup_staging (
+          type_hash bigint,
+          type_uri text,
+          simple_label text
+        );
+
+        return true;
+      END
+      $create_staging_tables$
+      language plpgsql
+      security definer
+      set search_path=%1$I,public;
+
+  $format$, CURRENT_SCHEMA);
+  END;
+$do$;
+comment on function  create_staging_tables() is 'Create the staging tables for graph import';
+
+--rollback drop function if exists create_staging_tables()

--- a/src/main/resources/changelog/scripts/v-1.0.0/resource_graph/functions/drop_staging_tables.sql
+++ b/src/main/resources/changelog/scripts/v-1.0.0/resource_graph/functions/drop_staging_tables.sql
@@ -1,0 +1,58 @@
+--liquibase formatted sql
+
+--changeset dfeeney@ebsco.com:3.11_drop_staging_tables_function dbms:postgresql splitStatements:false
+do $do$
+  BEGIN
+
+    execute format($format$
+      create or replace function %1$I.drop_staging_tables() returns boolean as
+      $drop_staging_tables$
+      DECLARE
+        partitioned_list text[] := array[
+          'resources_staging',
+          'resource_edges_staging',
+          'resource_generator_map_staging',
+          'generator_manifest_staging',
+          'resource_context_map_staging',
+          'resource_type_map_staging'
+        ];
+        partition_schema text;
+        partition_table text;
+        staging_table text;
+        parent_table regclass;
+      BEGIN
+        foreach staging_table in array partitioned_list loop
+          if exists(select 1 from information_schema.tables
+                    where table_schema=%1$L and table_name=staging_table) then
+            for partition_schema, partition_table in
+              select
+                 nsp.nspname, tbl.relname
+              from pg_catalog.pg_inherits i
+              join pg_class tbl on i.inhrelid=tbl.oid
+              join pg_namespace nsp  on nsp.oid=tbl.relnamespace
+              where i.inhparent = format('%%I.%%I', %1$L, staging_table)::regclass
+            loop
+              execute format('drop table if exists %%I.%%I', partition_schema, partition_table);
+            end loop;
+            execute format('drop table if exists %%I.%%I', %1$L, staging_table);
+          end if;
+        end loop;
+
+        drop table if exists %1$I.context_lookup_staging;
+        drop table if exists %1$I.predicate_lookup_staging;
+        drop table if exists %1$I.type_lookup_staging;
+
+        return true;
+      END
+      $drop_staging_tables$
+      language plpgsql
+      security definer
+      set search_path=%1$I,public;
+
+  $format$, CURRENT_SCHEMA);
+comment on function drop_staging_tables() is 'Drop the staging tables for graph import';
+
+  END;
+$do$;
+
+--rollback drop function if exists drop_staging_tables()


### PR DESCRIPTION
This adds two new functions for creating and destroying staging table for merging data from a data graph into a tenant's graph. It also fixes a bug couple of pre-existing bugs.

The create function creates a staging table and corresponding partitions for each table to be merged. The partitioning configuration matches the existing partitioning configuration for the graph tables. Tables are named `<graph_table_name>_staging`. 

For example, for merging the `resources` table, A `resources_staging` table will be created as well as (by default) 4 partitions. Lookup tables are not partitioned, so `context_lookup` will have a corresponding `context_lookup_staging` table.