### PR TITLE
MODLD-385: Move kafka topic creation to mod-linked-data

### DIFF
--- a/src/main/java/org/folio/linked/data/service/impl/tenant/LinkedTenantService.java
+++ b/src/main/java/org/folio/linked/data/service/impl/tenant/LinkedTenantService.java
@@ -32,12 +32,12 @@ public class LinkedTenantService extends TenantService {
   @Override
   public void beforeTenantUpdate(TenantAttributes tenantAttributes) {
     log.debug("Start before actions for the tenant [{}]", context.getTenantId());
-    workers.forEach(worker -> worker.beforeTenantUpdate(tenantAttributes));
+    workers.forEach(worker -> worker.beforeTenantUpdate(context.getTenantId(), tenantAttributes));
   }
 
   @Override
   public void afterTenantUpdate(TenantAttributes tenantAttributes) {
     log.info("Start after actions for the tenant [{}]", context.getTenantId());
-    workers.forEach(worker -> worker.afterTenantUpdate(tenantAttributes));
+    workers.forEach(worker -> worker.afterTenantUpdate(context.getTenantId(), tenantAttributes));
   }
 }

--- a/src/main/java/org/folio/linked/data/service/impl/tenant/TenantServiceWorker.java
+++ b/src/main/java/org/folio/linked/data/service/impl/tenant/TenantServiceWorker.java
@@ -4,11 +4,11 @@ import org.folio.tenant.domain.dto.TenantAttributes;
 
 public interface TenantServiceWorker {
 
-  default void beforeTenantUpdate(TenantAttributes tenantAttributes) {
+  default void beforeTenantUpdate(String tenantId, TenantAttributes tenantAttributes) {
     // no action by default
   }
 
-  default void afterTenantUpdate(TenantAttributes tenantAttributes) {
+  default void afterTenantUpdate(String tenantId, TenantAttributes tenantAttributes) {
     // no action by default
   }
 }

--- a/src/main/java/org/folio/linked/data/service/impl/tenant/workers/DictionaryWorker.java
+++ b/src/main/java/org/folio/linked/data/service/impl/tenant/workers/DictionaryWorker.java
@@ -19,7 +19,7 @@ public class DictionaryWorker implements TenantServiceWorker {
   private final DictionaryService dictionaryService;
 
   @Override
-  public void afterTenantUpdate(TenantAttributes tenantAttributes) {
+  public void afterTenantUpdate(String tenantId, TenantAttributes tenantAttributes) {
     dictionaryService.init();
     log.info("Dictionaries updated");
   }

--- a/src/main/java/org/folio/linked/data/service/impl/tenant/workers/KafkaAdminWorker.java
+++ b/src/main/java/org/folio/linked/data/service/impl/tenant/workers/KafkaAdminWorker.java
@@ -1,0 +1,20 @@
+package org.folio.linked.data.service.impl.tenant.workers;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.linked.data.service.impl.tenant.TenantServiceWorker;
+import org.folio.spring.tools.kafka.KafkaAdminService;
+import org.folio.tenant.domain.dto.TenantAttributes;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaAdminWorker implements TenantServiceWorker {
+
+  private final KafkaAdminService kafkaAdminService;
+
+  @Override
+  public void afterTenantUpdate(String tenantId, TenantAttributes tenantAttributes) {
+    kafkaAdminService.createTopics(tenantId);
+    kafkaAdminService.restartEventListeners();
+  }
+}

--- a/src/main/java/org/folio/linked/data/service/impl/tenant/workers/SearchWorker.java
+++ b/src/main/java/org/folio/linked/data/service/impl/tenant/workers/SearchWorker.java
@@ -23,7 +23,7 @@ public class SearchWorker implements TenantServiceWorker {
   private final SearchClient searchClient;
 
   @Override
-  public void afterTenantUpdate(TenantAttributes tenantAttributes) {
+  public void afterTenantUpdate(String tenantId, TenantAttributes tenantAttributes) {
     try {
       var request = new CreateIndexRequest(SEARCH_RESOURCE_NAME);
       ResponseEntity<FolioCreateIndexResponse> response = searchClient.createIndex(request);

--- a/src/main/resources/application-search.yml
+++ b/src/main/resources/application-search.yml
@@ -26,3 +26,12 @@ mod-linked-data:
   kafka:
     topic:
       bibframe-index: search.bibframe
+
+folio:
+  kafka:
+    retry-interval-ms: ${KAFKA_RETRY_INTERVAL_MS:2000}
+    retry-delivery-attempts: ${KAFKA_RETRY_DELIVERY_ATTEMPTS:6}
+    topics:
+      - name: ${mod-linked-data.kafka.topic.bibframe-index:search.bibframe}
+        numPartitions: ${KAFKA_BIBFRAME_TOPIC_PARTITIONS:3}
+        replicationFactor: ${KAFKA_BIBFRAME_TOPIC_REPLICATION_FACTOR:}

--- a/src/test/java/org/folio/linked/data/service/impl/tenant/LinkedTenantServiceTest.java
+++ b/src/test/java/org/folio/linked/data/service/impl/tenant/LinkedTenantServiceTest.java
@@ -2,6 +2,7 @@ package org.folio.linked.data.service.impl.tenant;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.folio.spring.FolioExecutionContext;
@@ -20,15 +21,16 @@ import org.springframework.jdbc.core.JdbcTemplate;
 class LinkedTenantServiceTest {
 
   @Mock
-  JdbcTemplate jdbcTemplate;
+  private JdbcTemplate jdbcTemplate;
   @Mock
-  FolioExecutionContext context;
+  private FolioExecutionContext context;
   @Mock
-  FolioSpringLiquibase folioSpringLiquibase;
+  private FolioSpringLiquibase folioSpringLiquibase;
   @Mock
-  TenantServiceWorker testWorker;
+  private TenantServiceWorker testWorker;
 
-  LinkedTenantService tenantService;
+  private LinkedTenantService tenantService;
+  private final String tenantId = "tenant-01";
 
   @BeforeEach
   void init() {
@@ -38,6 +40,7 @@ class LinkedTenantServiceTest {
       folioSpringLiquibase,
       List.of(testWorker)
     );
+    when(context.getTenantId()).thenReturn(tenantId);
   }
 
   @Test
@@ -50,7 +53,7 @@ class LinkedTenantServiceTest {
 
     //then
     verify(testWorker)
-      .beforeTenantUpdate(attributes);
+      .beforeTenantUpdate(tenantId, attributes);
   }
 
   @Test
@@ -63,6 +66,6 @@ class LinkedTenantServiceTest {
 
     //then
     verify(testWorker)
-      .afterTenantUpdate(attributes);
+      .afterTenantUpdate(tenantId, attributes);
   }
 }

--- a/src/test/java/org/folio/linked/data/service/impl/tenant/workers/KafkaAdminWorkerTest.java
+++ b/src/test/java/org/folio/linked/data/service/impl/tenant/workers/KafkaAdminWorkerTest.java
@@ -3,8 +3,8 @@ package org.folio.linked.data.service.impl.tenant.workers;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import org.folio.linked.data.service.DictionaryService;
 import org.folio.spring.testing.type.UnitTest;
+import org.folio.spring.tools.kafka.KafkaAdminService;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,25 +14,24 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class DictionaryWorkerTest {
-
+class KafkaAdminWorkerTest {
   @Mock
-  private DictionaryService dictionaryService;
+  private KafkaAdminService kafkaAdminService;
 
   @InjectMocks
-  private DictionaryWorker dictionaryWorker;
+  private KafkaAdminWorker kafkaAdminWorker;
 
   @Test
-  void shouldInitDictionaries() {
-    //given
+  void shouldCreateTopics() {
+    // given
     var attributes = mock(TenantAttributes.class);
     var tenantId = "tenant-01";
 
-    //when
-    dictionaryWorker.afterTenantUpdate(tenantId, attributes);
+    // when
+    kafkaAdminWorker.afterTenantUpdate(tenantId, attributes);
 
-    //then
-    verify(dictionaryService)
-      .init();
+    // then
+    verify(kafkaAdminService).createTopics(tenantId);
+    verify(kafkaAdminService).restartEventListeners();
   }
 }

--- a/src/test/java/org/folio/linked/data/service/impl/tenant/workers/SearchWorkerTest.java
+++ b/src/test/java/org/folio/linked/data/service/impl/tenant/workers/SearchWorkerTest.java
@@ -28,9 +28,10 @@ class SearchWorkerTest {
     //given
     var expectedRequest = new CreateIndexRequest("bibframe");
     var attributes = mock(TenantAttributes.class);
+    var tenantId = "tenant-01";
 
     //when
-    searchWorker.afterTenantUpdate(attributes);
+    searchWorker.afterTenantUpdate(tenantId, attributes);
 
     //then
     verify(searchClient).createIndex(expectedRequest);


### PR DESCRIPTION
Per FOLIO policy, application that produces the event should be resoponsible for creating KAFKA topics (not the applications that consume the events).

Pavlo has added this as a comment in this PR -> https://github.com/folio-org/mod-search/pull/587#discussion_r1612108421 
